### PR TITLE
plugins: Fix handling when there are plugins

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -16,5 +16,5 @@
     name={{ item }}
     state=disabled
   notify: restart rabbitmq-server
-  with_items: "{{ result.stdout_lines }}"
+  with_items: "{{ result.get('stdout_lines', []) }}"
   when: rabbitmq_plugins == []


### PR DESCRIPTION
The `results.stdout_lines` is still checked even when the `when` is false.
If there are no lines then we can evaluate it with an empty list.

@reactiveops/technical-team-members 